### PR TITLE
add separate env vars for the l1 owner + admin and the l2 owner + admin.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,13 @@
 # private key for the executor of the scripts (account must be funded)
 DEPLOYER_PRIVATE_KEY=0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6 # TODO: change this (0xa0Ee7A142d267C1f36714E4a8F75612F20a79720)
-# address of the account that will have admin rights over the proxies
-ADDRESS_PROXY_ADMIN=0x14dC79964da2C08b23698B3D3cc7Ca32193d9955 # TODO: change this
-# address of the account that will be the owner of the contracts
-ADDRESS_OWNER=0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f # TODO: change this
+# address of the L1 account that will have admin rights over the L1Escrow proxy
+ADDRESS_L1_PROXY_ADMIN=0x14dC79964da2C08b23698B3D3cc7Ca32193d9955 # TODO: change this
+# address of the L1 account that will be the owner of the l1Escrow contract
+ADDRESS_L1_OWNER=0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f # TODO: change this
+# address of the L2 account that will have admin rights over the ZKMinterBurner and NativeConverter proxies
+ADDRESS_L2_PROXY_ADMIN=0x14dC79964da2C08b23698B3D3cc7Ca32193d9955 # TODO: change this
+# address of the L2 account that will be the owner of the ZKMinterBurner and NativeConverter contracts
+ADDRESS_L2_OWNER=0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f # TODO: change this
 
 # bridge and token address
 ADDRESS_LXLY_BRIDGE=0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe # NOTE: same address for both L1/L2 when eth/zkevm

--- a/scripts/DeployInit.s.sol
+++ b/scripts/DeployInit.s.sol
@@ -31,10 +31,14 @@ contract DeployInit is Script {
     address zkUSDCe = vm.envAddress("ADDRESS_L2_USDC"); // ATTN: needs to be deployed beforehand zkUsdc
     address zkBWUSDC = vm.envAddress("ADDRESS_L2_WUSDC");
 
-    /// @notice the address that is able to upgrade the proxy contract's implementation contract
-    address admin = vm.envAddress("ADDRESS_PROXY_ADMIN");
-    /// @notice the address that is able to pause and unpause the l1Escrow, zkMinterBurner, and nativeConverter contracts
-    address owner = vm.envAddress("ADDRESS_OWNER");
+    /// @notice the L1 address that is able to upgrade the L1Escrow's proxy contract's implementation contract
+    address l1Admin = vm.envAddress("ADDRESS_L1_PROXY_ADMIN");
+    /// @notice the L1 address that is able to pause and unpause the L1Escrow contract
+    address l1Owner = vm.envAddress("ADDRESS_L1_OWNER");
+    /// @notice the L2 address that is able to upgrade the ZKMinterBurner and NativeConverter's proxy contracts' implementation contracts
+    address l2Admin = vm.envAddress("ADDRESS_L2_PROXY_ADMIN");
+    /// @notice the L1 address that is able to pause and unpause the ZKMinterBurner and NativeConverter contracts
+    address l2Owner = vm.envAddress("ADDRESS_L2_OWNER");
 
     function run() external {
         // deploy L1 contract
@@ -56,8 +60,8 @@ contract DeployInit is Script {
         vm.selectFork(l1ForkId);
         vm.startBroadcast(vm.envUint("DEPLOYER_PRIVATE_KEY"));
         L1Escrow l1Escrow = LibDeployInit.initL1Contracts(
-            owner,
-            admin,
+            l1Owner,
+            l1Admin,
             l2NetworkId,
             bridge,
             l1EscrowProxy,
@@ -73,8 +77,8 @@ contract DeployInit is Script {
             ZkMinterBurner minterBurner,
             NativeConverter nativeConverter
         ) = LibDeployInit.initL2Contracts(
-                owner,
-                admin,
+                l2Owner,
+                l2Admin,
                 l1NetworkId,
                 bridge,
                 l1EscrowProxy,


### PR DESCRIPTION
Prior to this commit, the deploy script assumed the owner + admin of the L1 and L2 contracts was the same address. This is not always the case, so we add 2 more env vars here and update the deploy script to allow for the L2 and L1 contracts to be owned by separate addresses.